### PR TITLE
Fix transcript serialization

### DIFF
--- a/src/fs_utils.rs
+++ b/src/fs_utils.rs
@@ -163,8 +163,13 @@ impl<F: Field> Serialize for EVMFs<F> {
         S: serde::Serializer,
     {
         let mut state = serializer.serialize_struct("EVMFs", 2)?;
-        state.serialize_field("transcript", &self.transcript)?;
-        state.serialize_field("state", &self.state)?;
+        let transcript_hex = format!("0x{}", hex::encode(&self.transcript));
+        state.serialize_field("transcript", &transcript_hex)?;
+        assert!(
+            self.state.is_empty(),
+            "State should be empty when serializing"
+        );
+        state.skip_field("state")?;
         state.end()
     }
 }

--- a/src/whir/mod.rs
+++ b/src/whir/mod.rs
@@ -134,11 +134,13 @@ mod evm_tests {
             .evm_prove(&mut evmfs_merlin, statement.clone(), evm_witness)
             .unwrap();
         let mut evmfs_arthur = evmfs_merlin.to_arthur();
+        // Return the untouched transcript
+        let proof_transcript = evmfs_arthur.clone();
         assert!(verifier
             .evm_verify(&mut evmfs_arthur, &statement, &evm_proof)
             .is_ok());
 
-        (evmfs_arthur, statement, evm_proof)
+        (proof_transcript, statement, evm_proof)
     }
 
     #[test]


### PR DESCRIPTION
Serializing as hex bytes for compatibility with Solidity. Added assertion to make sure that the transcript state is clean before serialization.